### PR TITLE
feat: DateFormatter — tempo relativo customizável (v2.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ npx vitest run -t "valida senha forte"                            # tests matchi
 
 - `validate` → `Validator` — `username`, `hashtag`, `url`, `description`, `name`, `password`
 - `extract` → `Extractor` (`content`), `KeywordExtractor` (`keywords`), `SentimentExtractor` (`sentiment`)
-- `transform` → `Conversor` (number/text formatting), `RichText`, `Timezone`
+- `transform` → `Conversor` (number/text formatting), `RichText`, `Timezone`, `DateFormatter` (customizable relative time; depends on `Timezone` for absolute formatting but is independently usable)
 
 Each specialized class lives under `src/classes/` and is independently usable; `TextLibrary` just composes them. `src/types.ts` holds the shared interface contracts (the `CircleText*` interfaces describe the facade's shape — note the class itself is named `TextLibrary`).
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Biblioteca **JavaScript/TypeScript** para **validação, extração e análise d
 - 🫀 **Sentimento** — léxico **pt-BR e inglês** + regras, com explicabilidade.
 - 🔍 **Keywords** — extração com stemming/stopwords pt-BR.
 - 🌍 **Timezone** — `Intl` nativo, com horário de verão automático.
+- 📅 **Datas** — tempo relativo **customizável** (pt-BR/en-US): "agora mesmo", "há 3 horas", "ontem".
 - 🔤 **Formatadores** — número/texto locale-aware.
 - 💉 **DI de verdade** — cada engine recebe config por construtor; a classe mãe só injeta.
 
@@ -66,6 +67,7 @@ Cada engine tem um guia detalhado com API, configuração e **casos de uso**:
 | 🫀 **SentimentExtractor** | `circle-text-library/sentiment` | [docs/sentiment.md](./docs/sentiment.md) |
 | 🔍 **KeywordExtractor** | `circle-text-library/keywords` | [docs/keywords.md](./docs/keywords.md) |
 | 🌍 **Timezone** | `circle-text-library/timezone` | [docs/timezone.md](./docs/timezone.md) |
+| 📅 **DateFormatter** | `circle-text-library/date` | [docs/date.md](./docs/date.md) |
 | 🔤 **Formatadores** | `circle-text-library/conversor` | [docs/formatter.md](./docs/formatter.md) |
 
 > **Decisões de arquitetura** (um `.md` de fluxo por engine): veja a pasta [`docs/`](./docs) (`*-flow.md`).
@@ -81,7 +83,7 @@ import type {
     TextLibraryConfig, Configurable, DeepPartial,
     ValidationConfig, ValidationResult,
     SentimentExtractorConfig, SentimentReturnProps, SentimentLanguage,
-    KeywordExtractorConfig, TimezoneConfig, FormatterConfig
+    KeywordExtractorConfig, TimezoneConfig, DateFormatterConfig, FormatterConfig
 } from "circle-text-library"
 ```
 
@@ -121,6 +123,7 @@ src/
 │   ├── sentimentExtractor/  # SentimentExtractor (pt-BR + en)
 │   ├── keywordExtractor.ts  # KeywordExtractor
 │   ├── timezone/            # Timezone (Intl)
+│   ├── date/                # DateFormatter (tempo relativo customizável)
 │   └── conversor/           # NumberFormatter / TextFormatter / Formatter
 └── data/
     ├── pt-br/               # léxicos e listas pt-BR (JSON estáticos)

--- a/docs/date.md
+++ b/docs/date.md
@@ -1,0 +1,199 @@
+# 📅 DateFormatter
+
+Engine independente para **tempo relativo customizável** ("to relative time") — "agora mesmo", "há 3 horas", "ontem", "em 5 minutos" — em **pt-BR**, **en-US** ou qualquer locale BCP-47. É **separada do `Timezone`**: o tempo relativo não depende de nenhum fuso, mas a classe **conversa com o `Timezone`** quando você precisa de formatação **absoluta** (DST automático). O relógio é **injetável**, o que torna os testes determinísticos.
+
+```typescript
+import { DateFormatter } from "circle-text-library/date"
+```
+
+---
+
+## API
+
+```typescript
+// Estático (locale default pt-BR, relógio do sistema)
+DateFormatter.fromNow(input): string
+DateFormatter.toRelativeTime(input): string
+
+// Instância
+const df = new DateFormatter(config?)
+df.fromNow(input): string                       // tempo relativo customizável
+df.toRelativeTime(input): string                // alias de fromNow
+df.format(input, options?): string              // absoluto, via Timezone
+df.fromNowOrDate(input, withinSeconds?, dateOptions?): string  // híbrido "feed"
+df.withConfig(patch): DateFormatter             // imutável
+df.withTimezone(tz): DateFormatter              // amarra a um Timezone (DI)
+df.config                                        // readonly
+```
+
+`input: DateInput` aceita **string ISO**, **epoch em ms** (`number`) ou **`Date`**. Entradas inválidas lançam `"Data inválida fornecida"`.
+
+---
+
+## Configuração
+
+```typescript
+interface DateFormatterConfig {
+    locale?: string                       // BCP-47; default "pt-BR" (use "en-US" p/ inglês)
+    now?: () => Date                      // relógio injetável; default () => new Date()
+    style?: "long" | "short" | "narrow"   // estilo das frases; default "long"
+    numeric?: "always" | "auto"           // "auto" → "ontem"; "always" → "há 1 dia"; default "auto"
+    maxUnit?: RelativeTimeUnit            // teto de unidade; default "year"
+    justNowThreshold?: number             // segundos abaixo dos quais vira "agora"; default 30
+    justNowLabel?: string                 // texto do "agora"; default pt "agora mesmo" / en "just now"
+    zone?: string                         // IANA p/ formatação absoluta; default fuso do sistema
+    timezone?: Timezone                   // instância de Timezone injetada (DI)
+}
+```
+
+`RelativeTimeUnit` é `"second" | "minute" | "hour" | "day" | "week" | "month" | "quarter" | "year"`.
+
+---
+
+## Tempo relativo (`fromNow` / `toRelativeTime`)
+
+```typescript
+const df = new DateFormatter({
+    locale: "pt-BR",
+    now: () => new Date("2024-01-15T15:30:00Z")   // relógio fixo p/ exemplo/teste
+})
+
+df.fromNow("2024-01-15T15:29:50Z")   // "agora mesmo"   (< 30s)
+df.fromNow("2024-01-15T12:30:00Z")   // "há 3 horas"
+df.fromNow("2024-01-14T15:30:00Z")   // "ontem"
+df.fromNow("2024-01-15T15:35:00Z")   // "em 5 minutos"  (futuro)
+```
+
+O mesmo em **inglês americano** — basta trocar o `locale`:
+
+```typescript
+const en = df.withConfig({ locale: "en-US" })
+
+en.fromNow("2024-01-15T12:30:00Z")   // "3 hours ago"
+en.fromNow("2024-01-14T15:30:00Z")   // "yesterday"
+en.fromNow("2024-01-15T15:29:55Z")   // "just now"
+```
+
+---
+
+## Customização
+
+### `style` — comprimento da frase
+
+```typescript
+new DateFormatter({ style: "long" }).fromNow(d)    // "há 3 horas"
+new DateFormatter({ style: "short" }).fromNow(d)   // "há 3 h"
+new DateFormatter({ style: "narrow" }).fromNow(d)  // "há 3 h" / "3h atrás"
+```
+
+### `numeric` — "ontem" vs "há 1 dia"
+
+```typescript
+new DateFormatter({ numeric: "auto" }).fromNow(ontem)     // "ontem"
+new DateFormatter({ numeric: "always" }).fromNow(ontem)   // "há 1 dia"
+```
+
+### `justNowThreshold` / `justNowLabel` — o "agora"
+
+```typescript
+// Trata qualquer coisa nos últimos 2 minutos como "agora mesmo".
+new DateFormatter({ justNowThreshold: 120 }).fromNow(ha90segundos)   // "agora mesmo"
+
+// Texto próprio.
+new DateFormatter({ justNowLabel: "agorinha" }).fromNow(ha5segundos) // "agorinha"
+```
+
+### `maxUnit` — teto de unidade
+
+```typescript
+// Sem teto: rola para meses/anos.
+new DateFormatter().fromNow(ha400dias)                 // "há 1 ano"
+
+// Capado em dias: nunca passa de dias.
+new DateFormatter({ maxUnit: "day" }).fromNow(ha400dias)   // "há 400 dias"
+```
+
+---
+
+## Formatação absoluta — conversa com o `Timezone`
+
+`format` delega ao `Timezone` (horário de verão tratado automaticamente). Você pode dar o fuso pela config (`zone`), injetar uma instância pronta (`timezone`) ou amarrar depois (`withTimezone`).
+
+```typescript
+// 1) fuso pela config
+const df = new DateFormatter({ zone: "America/Sao_Paulo", locale: "pt-BR" })
+df.format("2024-01-15T15:30:00Z")              // "15/01/2024, 12:30"
+df.format("2024-01-15T15:30:00Z", { dateStyle: "long" })  // "15 de janeiro de 2024"
+
+// 2) Timezone injetado (DI) — o locale do fuso é alinhado ao do DateFormatter
+import { Timezone } from "circle-text-library/timezone"
+const ny = new Timezone({ zone: "America/New_York" })
+new DateFormatter({ timezone: ny }).format("2024-01-15T15:30:00Z")  // horário de NY
+
+// 3) amarrar depois
+df.withTimezone(ny).format("2024-01-15T15:30:00Z")
+```
+
+`options` é um `Intl.DateTimeFormatOptions` mais um `zone?` pontual — a mesma assinatura de `Timezone.format`.
+
+---
+
+## Híbrido estilo "feed" (`fromNowOrDate`)
+
+Tempo relativo enquanto o instante é recente; **data absoluta** quando ultrapassa a janela — o padrão de timeline das redes sociais.
+
+```typescript
+const df = new DateFormatter({ zone: "America/Sao_Paulo", now: () => new Date("2024-01-15T15:30:00Z") })
+
+df.fromNowOrDate("2024-01-15T12:30:00Z")   // "há 3 horas"            (dentro de 7 dias)
+df.fromNowOrDate("2022-12-11T15:30:00Z")   // "11 de dez. de 2022"    (passou da janela)
+
+// Janela e formato da data são configuráveis por chamada:
+df.fromNowOrDate(iso, 24 * 60 * 60, { dateStyle: "short" })  // relativo só nas últimas 24h
+```
+
+---
+
+## Casos de uso
+
+### "Postado há…" num feed (pt-BR e en-US)
+
+```typescript
+const ptBR = new DateFormatter()                       // pt-BR, fuso do sistema
+const enUS = new DateFormatter({ locale: "en-US" })
+
+ptBR.fromNow(post.createdAt)   // "há 5 minutos"
+enUS.fromNow(post.createdAt)   // "5 minutes ago"
+```
+
+### Timeline estilo Twitter (relativo → data)
+
+```typescript
+const df = new DateFormatter({ zone: "America/Sao_Paulo" })
+function timestamp(iso: string) {
+    return df.fromNowOrDate(iso)   // "agora mesmo" → "há 2 h" → "11 de dez. de 2022"
+}
+```
+
+### Testes determinísticos
+
+```typescript
+const df = new DateFormatter({ now: () => new Date("2024-01-15T15:30:00Z") })
+expect(df.fromNow("2024-01-15T15:29:00Z")).toBe("há 1 minuto")
+```
+
+### Via fachada `TextLibrary`
+
+O `DateFormatter` é exposto como `date` e, por padrão, **conversa com o mesmo `Timezone`** da fachada:
+
+```typescript
+import { TextLibrary } from "circle-text-library"
+
+const ct = new TextLibrary({
+    timezone: { zone: "America/Sao_Paulo" },
+    date: { locale: "pt-BR", justNowThreshold: 60 }
+})
+
+ct.date.fromNow("2024-01-15T12:30:00Z")   // "há 3 horas"
+ct.date.format("2024-01-15T15:30:00Z")    // usa o fuso de São Paulo da fachada
+```

--- a/docs/text-library.md
+++ b/docs/text-library.md
@@ -21,11 +21,12 @@ ct.sentiment.analyze("isso é ótimo demais")  // { sentiment: "positive", inten
 ct.keywords.extract("inteligência artificial revoluciona a programação")
 // ["intelig", "artifici", "revoluciona", "programacao"]
 ct.timezone.format("2024-01-15T15:30:00Z")   // data no fuso configurado
+ct.date.fromNow("2024-01-15T12:30:00Z")      // tempo relativo: "há 3 horas"
 ct.format.number.compact(12500)              // "12,5 mil"
 ct.format.text.slug("Olá Mundo")             // "ola-mundo"
 ```
 
-Slots disponíveis no construtor: `validation`, `sentiment`, `keywords`, `richText`, `timezone`, `format`. Cada um aceita **uma config** (a mãe constrói a engine) **ou** uma **instância pronta** (DI).
+Slots disponíveis no construtor: `validation`, `sentiment`, `keywords`, `richText`, `timezone`, `date`, `format`. Cada um aceita **uma config** (a mãe constrói a engine) **ou** uma **instância pronta** (DI). O slot `date` ([`DateFormatter`](./date.md)) conversa, por padrão, com o mesmo `Timezone` da fachada.
 
 > **Atenção ao RichText:** os métodos de instância do `RichText` operam sobre o texto do construtor, e o facade cria a engine sem texto. Para analisar textos avulsos, use o import dedicado (`RichText.parse(text)` / `new RichText(text, opts)`) — veja [`rich-text.md`](./rich-text.md). O slot `richText` serve sobretudo para carregar config/DI.
 
@@ -71,6 +72,7 @@ import { RichText } from "circle-text-library/rich-text"
 import { SentimentExtractor } from "circle-text-library/sentiment"
 import { KeywordExtractor } from "circle-text-library/keywords"
 import { Timezone } from "circle-text-library/timezone"
+import { DateFormatter } from "circle-text-library/date"
 import { NumberFormatter, TextFormatter } from "circle-text-library/conversor"
 ```
 
@@ -85,6 +87,6 @@ import type {
     TextLibraryConfig, Configurable, DeepPartial,
     ValidationConfig, ValidationResult,
     SentimentExtractorConfig, SentimentReturnProps, SentimentLanguage,
-    KeywordExtractorConfig, TimezoneConfig, FormatterConfig
+    KeywordExtractorConfig, TimezoneConfig, DateFormatterConfig, FormatterConfig
 } from "circle-text-library"
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "circle-text-library",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Biblioteca JavaScript/TypeScript para validação, extração e análise de texto (sentimento pt-BR/inglês, keywords, rich text, timezone, formatação), desenvolvida para o Circle App",
     "type": "module",
     "main": "./dist/src/index.js",
@@ -16,6 +16,11 @@
             "types": "./dist/src/classes/timezone/index.d.ts",
             "import": "./dist/src/classes/timezone/index.js",
             "require": "./dist/src/classes/timezone/index.js"
+        },
+        "./date": {
+            "types": "./dist/src/classes/date/index.d.ts",
+            "import": "./dist/src/classes/date/index.js",
+            "require": "./dist/src/classes/date/index.js"
         },
         "./sentiment": {
             "types": "./dist/src/classes/sentimentExtractor/index.d.ts",

--- a/src/classes/date/__tests__/date.spec.ts
+++ b/src/classes/date/__tests__/date.spec.ts
@@ -1,0 +1,174 @@
+import { DateFormatter } from "../index"
+import { Timezone } from "../../timezone/index"
+import { describe, expect, it } from "vitest"
+
+// Instante UTC de referência usado como "agora" injetado: 2024-01-15 15:30:00 UTC.
+const UTC_INSTANT = "2024-01-15T15:30:00Z"
+const fixedNow = () => new Date(UTC_INSTANT)
+const baseMs = new Date(UTC_INSTANT).getTime()
+const ago = (seconds: number) => new Date(baseMs - seconds * 1000)
+const ahead = (seconds: number) => new Date(baseMs + seconds * 1000)
+
+const HOUR = 60 * 60
+const DAY = 24 * HOUR
+
+describe("DateFormatter (tempo relativo customizável, v2)", () => {
+    describe("fromNow() — pt-BR (default)", () => {
+        const df = new DateFormatter({ now: fixedNow })
+
+        it("retorna 'há 3 horas' para 3h no passado", () => {
+            expect(df.fromNow(ago(3 * HOUR))).toBe("há 3 horas")
+        })
+
+        it("retorna 'agora mesmo' para o instante atual (dentro do limiar)", () => {
+            expect(df.fromNow(UTC_INSTANT)).toBe("agora mesmo")
+            expect(df.fromNow(ago(10))).toBe("agora mesmo")
+        })
+
+        it("retorna 'ontem' para ~24h no passado (numeric auto)", () => {
+            expect(df.fromNow(ago(DAY))).toBe("ontem")
+        })
+
+        it("retorna 'anteontem' para ~48h no passado", () => {
+            expect(df.fromNow(ago(2 * DAY))).toBe("anteontem")
+        })
+
+        it("retorna 'há 4 dias' para ~96h no passado", () => {
+            expect(df.fromNow(ago(4 * DAY))).toBe("há 4 dias")
+        })
+
+        it("suporta futuro: 'em 5 minutos'", () => {
+            expect(df.fromNow(ahead(5 * 60))).toBe("em 5 minutos")
+        })
+
+        it("toRelativeTime é alias de fromNow", () => {
+            expect(df.toRelativeTime(ago(3 * HOUR))).toBe(df.fromNow(ago(3 * HOUR)))
+        })
+    })
+
+    describe("fromNow() — en-US", () => {
+        const df = new DateFormatter({ locale: "en-US", now: fixedNow })
+
+        it("retorna '3 hours ago'", () => {
+            expect(df.fromNow(ago(3 * HOUR))).toBe("3 hours ago")
+        })
+
+        it("retorna 'yesterday' para ~24h no passado", () => {
+            expect(df.fromNow(ago(DAY))).toBe("yesterday")
+        })
+
+        it("usa 'just now' como justNow default em inglês", () => {
+            expect(df.fromNow(ago(5))).toBe("just now")
+        })
+    })
+
+    describe("customização", () => {
+        it("justNowLabel sobrescreve o texto do 'agora'", () => {
+            const df = new DateFormatter({ now: fixedNow, justNowLabel: "agorinha" })
+            expect(df.fromNow(ago(5))).toBe("agorinha")
+        })
+
+        it("justNowThreshold amplia/reduz a janela do 'agora'", () => {
+            const wide = new DateFormatter({ now: fixedNow, justNowThreshold: 120 })
+            expect(wide.fromNow(ago(90))).toBe("agora mesmo")
+
+            const tight = new DateFormatter({ now: fixedNow, justNowThreshold: 0 })
+            expect(tight.fromNow(ago(1))).toBe("há 1 segundo")
+        })
+
+        it("style 'short' encurta a frase", () => {
+            const df = new DateFormatter({ now: fixedNow, style: "short" })
+            expect(df.fromNow(ago(3 * HOUR))).toContain("3")
+        })
+
+        it("numeric 'always' força 'há 1 dia' em vez de 'ontem'", () => {
+            const df = new DateFormatter({ now: fixedNow, numeric: "always" })
+            expect(df.fromNow(ago(DAY))).toBe("há 1 dia")
+        })
+
+        it("maxUnit 'day' capa em dias em vez de rolar para meses/anos", () => {
+            const df = new DateFormatter({ now: fixedNow, maxUnit: "day" })
+            const out = df.fromNow(ago(400 * DAY))
+            expect(out).toContain("400")
+            expect(out).toContain("dia")
+        })
+    })
+
+    describe("format() — absoluto via Timezone", () => {
+        it("usa o fuso da config (zone) para formatar o instante UTC", () => {
+            const df = new DateFormatter({ zone: "America/Sao_Paulo", locale: "pt-BR", now: fixedNow })
+            const out = df.format(UTC_INSTANT)
+            // 15:30 UTC = 12:30 em São Paulo (sem horário de verão em jan/2024).
+            expect(out).toContain("12:30")
+            expect(out).toContain("15/01/2024")
+        })
+
+        it("delega a um Timezone injetado (DI)", () => {
+            const tz = new Timezone({ zone: "America/New_York", locale: "pt-BR" })
+            const df = new DateFormatter({ timezone: tz, now: fixedNow })
+            // 15:30 UTC = 10:30 em Nova York (inverno).
+            expect(df.format(UTC_INSTANT)).toContain("10:30")
+        })
+
+        it("alinha o locale do Timezone injetado ao do DateFormatter", () => {
+            const tz = new Timezone({ zone: "UTC", locale: "pt-BR" })
+            const df = new DateFormatter({ locale: "en-US", timezone: tz })
+            expect(df.format(UTC_INSTANT, { dateStyle: "long" })).toContain("January")
+        })
+
+        it("withTimezone deriva uma instância amarrada a outro fuso", () => {
+            const df = new DateFormatter({ now: fixedNow }).withTimezone(
+                new Timezone({ zone: "UTC", locale: "pt-BR" })
+            )
+            expect(df.format(UTC_INSTANT)).toContain("15:30")
+        })
+    })
+
+    describe("fromNowOrDate() — híbrido feed", () => {
+        const df = new DateFormatter({ zone: "UTC", locale: "pt-BR", now: fixedNow })
+
+        it("usa tempo relativo quando recente (dentro da janela)", () => {
+            expect(df.fromNowOrDate(ago(3 * HOUR))).toBe("há 3 horas")
+        })
+
+        it("cai para data absoluta quando passa da janela", () => {
+            const out = df.fromNowOrDate(ago(400 * DAY))
+            expect(out).toContain("2022")
+        })
+    })
+
+    describe("withConfig() / Configurable", () => {
+        it("expõe config readonly com os valores fornecidos", () => {
+            const df = new DateFormatter({ locale: "en-US", style: "short" })
+            expect(df.config.locale).toBe("en-US")
+            expect(df.config.style).toBe("short")
+        })
+
+        it("withConfig deriva nova instância com patch, sem mutar a original", () => {
+            const base = new DateFormatter({ locale: "pt-BR", now: fixedNow })
+            const derived = base.withConfig({ locale: "en-US" })
+
+            expect(derived).not.toBe(base)
+            expect(derived).toBeInstanceOf(DateFormatter)
+            expect(base.fromNow(ago(3 * HOUR))).toBe("há 3 horas")
+            expect(derived.fromNow(ago(3 * HOUR))).toBe("3 hours ago")
+        })
+    })
+
+    describe("validação de entrada", () => {
+        const df = new DateFormatter({ now: fixedNow })
+
+        it("lança 'Data inválida fornecida' para entrada inválida", () => {
+            expect(() => df.fromNow("not a date")).toThrow("Data inválida fornecida")
+            expect(() => df.format(new Date("invalid"))).toThrow("Data inválida fornecida")
+        })
+    })
+
+    describe("conveniências estáticas", () => {
+        it("DateFormatter.fromNow retorna uma string não vazia", () => {
+            const out = DateFormatter.fromNow(new Date())
+            expect(typeof out).toBe("string")
+            expect(out.length).toBeGreaterThan(0)
+        })
+    })
+})

--- a/src/classes/date/date.types.ts
+++ b/src/classes/date/date.types.ts
@@ -1,0 +1,69 @@
+// Copyright 2025 Circle LLC
+// Licensed under the MIT License
+
+/**
+ * Tipos públicos do `DateFormatter`.
+ *
+ * O `DateFormatter` é uma engine independente focada em **tempo relativo**
+ * customizável (pt-BR / en-US e qualquer locale BCP-47). Ele conversa com o
+ * `Timezone` para formatação absoluta, mas pode ser instanciado sozinho. A
+ * implementação vive em `./index.ts`.
+ */
+
+import type { Timezone } from "../timezone/index.js"
+
+// `DateInput` é compartilhado com o `Timezone` (ISO string, epoch ms ou `Date`).
+import type { DateInput } from "../timezone/timezone.types.js"
+
+/** Unidade de tempo aceita pelo `Intl.RelativeTimeFormat`. */
+export type RelativeTimeUnit = Intl.RelativeTimeFormatUnit
+
+/**
+ * Configuração da engine de datas. Tudo opcional — os defaults entregam tempo
+ * relativo natural em pt-BR (`"long"`, `numeric: "auto"`, "agora mesmo" para o
+ * presente imediato).
+ */
+export interface DateFormatterConfig {
+    /** Locale BCP-47, ex.: `"pt-BR"` ou `"en-US"`. Default: `"pt-BR"`. */
+    locale?: string
+    /** Relógio injetável para testabilidade. Default: `() => new Date()`. */
+    now?: () => Date
+    /**
+     * Estilo das frases do `Intl.RelativeTimeFormat`:
+     * `"long"` ("há 3 horas"), `"short"` ("há 3 h"), `"narrow"` ("3 h atrás").
+     * Default: `"long"`.
+     */
+    style?: Intl.RelativeTimeFormatStyle
+    /**
+     * `"auto"` produz "ontem"/"amanhã"; `"always"` força "há 1 dia"/"em 1 dia".
+     * Default: `"auto"`.
+     */
+    numeric?: "always" | "auto"
+    /**
+     * Maior unidade permitida (teto). Ex.: `"day"` exibe "há 400 dias" em vez de
+     * roer para meses/anos. Default: `"year"`.
+     */
+    maxUnit?: RelativeTimeUnit
+    /**
+     * Abaixo deste número de segundos (em valor absoluto) o resultado é
+     * `justNowLabel` em vez de "há X segundos". Default: `30`.
+     */
+    justNowThreshold?: number
+    /**
+     * Texto usado quando a diferença está dentro de `justNowThreshold`.
+     * Default por locale: pt → `"agora mesmo"`, en → `"just now"`.
+     */
+    justNowLabel?: string
+    /**
+     * Fuso IANA usado na formatação absoluta (`format` / `fromNowOrDate`).
+     * Default: fuso detectado do sistema (via `Timezone`).
+     */
+    zone?: string
+    /**
+     * Instância de `Timezone` injetada para a formatação absoluta (DI). Quando
+     * ausente, o `DateFormatter` cria uma sob demanda a partir de `zone`/`locale`.
+     */
+    timezone?: Timezone
+}
+
+export type { DateInput }

--- a/src/classes/date/index.ts
+++ b/src/classes/date/index.ts
@@ -1,0 +1,221 @@
+// Copyright 2025 Circle LLC
+// Licensed under the MIT License
+
+import { Configurable, DeepPartial, mergeConfig } from "../../core/config.js"
+import { Timezone } from "../timezone/index.js"
+
+import type { TimezoneConfig } from "../timezone/timezone.types.js"
+import type { DateFormatterConfig, DateInput, RelativeTimeUnit } from "./date.types.js"
+
+// Reexporta os tipos públicos para manter a superfície de import do subpath.
+export type * from "./date.types.js"
+
+/** Unidades para o tempo relativo, da menor para a maior, com o fator de roll-over. */
+const BASE_DIVISIONS: { amount: number; unit: RelativeTimeUnit }[] = [
+    { amount: 60, unit: "second" },
+    { amount: 60, unit: "minute" },
+    { amount: 24, unit: "hour" },
+    { amount: 7, unit: "day" },
+    { amount: 4.34524, unit: "week" },
+    { amount: 12, unit: "month" },
+    { amount: Number.POSITIVE_INFINITY, unit: "year" }
+]
+
+const DEFAULT_LOCALE = "pt-BR"
+const DEFAULT_STYLE: Intl.RelativeTimeFormatStyle = "long"
+const DEFAULT_NUMERIC: "always" | "auto" = "auto"
+const DEFAULT_MAX_UNIT: RelativeTimeUnit = "year"
+const DEFAULT_JUST_NOW_THRESHOLD = 30
+
+/** Rótulo "agora" por idioma, usado quando `justNowLabel` não é informado. */
+const JUST_NOW_BY_LANG: Record<string, string> = {
+    pt: "agora mesmo",
+    en: "just now",
+    es: "ahora mismo",
+    fr: "à l'instant"
+}
+
+/**
+ * Engine de datas focada em **tempo relativo customizável** ("to relative time"),
+ * separada do `Timezone`. Os defaults entregam frases naturais em pt-BR, e cada
+ * eixo é configurável: idioma (pt-BR / en-US / qualquer BCP-47), estilo
+ * (`long`/`short`/`narrow`), `numeric`, unidade máxima e o limiar do "agora mesmo".
+ *
+ * Conversa com o `Timezone` para formatação **absoluta** (`format`,
+ * `fromNowOrDate`), mas pode ser instanciada sozinha — o tempo relativo não
+ * depende de nenhum fuso.
+ */
+export class DateFormatter implements Configurable<DateFormatterConfig> {
+    public readonly config: Readonly<DateFormatterConfig>
+
+    private readonly locale: string
+    private readonly clock: () => Date
+    private readonly style: Intl.RelativeTimeFormatStyle
+    private readonly numeric: "always" | "auto"
+    private readonly maxUnit: RelativeTimeUnit
+    private readonly justNowThreshold: number
+    private readonly justNowLabel: string
+    private readonly zone: string | undefined
+    private readonly injectedTz: Timezone | undefined
+    /** `Timezone` derivado, memoizado na primeira formatação absoluta. */
+    private tz: Timezone | undefined
+
+    constructor(config: DateFormatterConfig = {}) {
+        // exactOptionalPropertyTypes: só copiamos chaves realmente presentes.
+        const normalized: DateFormatterConfig = {}
+        if (config.locale !== undefined) normalized.locale = config.locale
+        if (config.now !== undefined) normalized.now = config.now
+        if (config.style !== undefined) normalized.style = config.style
+        if (config.numeric !== undefined) normalized.numeric = config.numeric
+        if (config.maxUnit !== undefined) normalized.maxUnit = config.maxUnit
+        if (config.justNowThreshold !== undefined)
+            normalized.justNowThreshold = config.justNowThreshold
+        if (config.justNowLabel !== undefined) normalized.justNowLabel = config.justNowLabel
+        if (config.zone !== undefined) normalized.zone = config.zone
+        if (config.timezone !== undefined) normalized.timezone = config.timezone
+
+        this.config = normalized
+        this.locale = normalized.locale ?? DEFAULT_LOCALE
+        this.clock = normalized.now ?? (() => new Date())
+        this.style = normalized.style ?? DEFAULT_STYLE
+        this.numeric = normalized.numeric ?? DEFAULT_NUMERIC
+        this.maxUnit = normalized.maxUnit ?? DEFAULT_MAX_UNIT
+        this.justNowThreshold = normalized.justNowThreshold ?? DEFAULT_JUST_NOW_THRESHOLD
+        this.justNowLabel = normalized.justNowLabel ?? DateFormatter.defaultJustNow(this.locale)
+        this.zone = normalized.zone
+        this.injectedTz = normalized.timezone
+    }
+
+    /**
+     * Tempo relativo a agora, customizável: "agora mesmo", "há 3 horas",
+     * "ontem", "há 2 dias", "em 5 minutos". Respeita `style`, `numeric`,
+     * `maxUnit`, `justNowThreshold` e o `locale` (pt-BR, en-US, …).
+     */
+    public fromNow(input: DateInput): string {
+        const deltaSeconds = (this.toDate(input).getTime() - this.clock().getTime()) / 1000
+        if (Math.abs(deltaSeconds) < this.justNowThreshold) return this.justNowLabel
+
+        const rtf = new Intl.RelativeTimeFormat(this.locale, {
+            numeric: this.numeric,
+            style: this.style
+        })
+
+        const divisions = this.divisions()
+        let delta = deltaSeconds
+        for (const { amount, unit } of divisions) {
+            if (Math.abs(delta) < amount) return rtf.format(Math.round(delta), unit)
+            delta /= amount
+        }
+        const last = divisions[divisions.length - 1]
+        return rtf.format(Math.round(delta), last ? last.unit : "year")
+    }
+
+    /** Alias semântico de `fromNow` ("to relative time"). */
+    public toRelativeTime(input: DateInput): string {
+        return this.fromNow(input)
+    }
+
+    /**
+     * Formatação **absoluta** delegada ao `Timezone` (DST automático). Aceita as
+     * mesmas `Intl.DateTimeFormatOptions` mais um `zone?` pontual.
+     */
+    public format(
+        input: DateInput,
+        options: Intl.DateTimeFormatOptions & { zone?: string } = {}
+    ): string {
+        return this.timezone().format(input, options)
+    }
+
+    /**
+     * Híbrido estilo "feed": tempo relativo enquanto o instante é recente; data
+     * absoluta quando ultrapassa `withinSeconds` (default 7 dias). Ex.: "há 5
+     * minutos" agora, "15 de jan. de 2024" semanas depois.
+     */
+    public fromNowOrDate(
+        input: DateInput,
+        withinSeconds: number = 7 * 24 * 60 * 60,
+        dateOptions: Intl.DateTimeFormatOptions & { zone?: string } = { dateStyle: "medium" }
+    ): string {
+        const deltaSeconds = Math.abs(
+            (this.toDate(input).getTime() - this.clock().getTime()) / 1000
+        )
+        return deltaSeconds <= withinSeconds ? this.fromNow(input) : this.format(input, dateOptions)
+    }
+
+    /** Deriva uma nova engine imutável aplicando o patch sobre a config atual. */
+    public withConfig(patch: DeepPartial<DateFormatterConfig>): this {
+        // Anota T explicitamente: a `Timezone` em config não deve virar
+        // DeepPartial<Timezone> na inferência (mesmo padrão do conversor).
+        const merged = mergeConfig<DateFormatterConfig>(this.config, patch)
+        return new DateFormatter(merged) as this
+    }
+
+    /** Deriva uma engine amarrada a um `Timezone` específico (DI explícita). */
+    public withTimezone(timezone: Timezone): this {
+        const merged: DateFormatterConfig = { ...this.config, timezone }
+        return new DateFormatter(merged) as this
+    }
+
+    // ── internos ────────────────────────────────────────────────────────────
+
+    /** Divisões capadas em `maxUnit` (a última nunca rola para a próxima unidade). */
+    private divisions(): { amount: number; unit: RelativeTimeUnit }[] {
+        const idx = BASE_DIVISIONS.findIndex((d) => d.unit === this.maxUnit)
+        const sliced = idx === -1 ? BASE_DIVISIONS : BASE_DIVISIONS.slice(0, idx + 1)
+        const lastIndex = sliced.length - 1
+        return sliced.map((d, i) =>
+            i === lastIndex ? { amount: Number.POSITIVE_INFINITY, unit: d.unit } : d
+        )
+    }
+
+    /** `Timezone` usado na formatação absoluta: injetado, derivado ou criado. */
+    private timezone(): Timezone {
+        if (!this.tz) {
+            if (this.injectedTz) {
+                // Alinha o locale do fuso injetado ao do DateFormatter, mantendo o fuso.
+                this.tz =
+                    this.injectedTz.config.locale === this.locale
+                        ? this.injectedTz
+                        : this.injectedTz.withConfig({ locale: this.locale })
+            } else {
+                const cfg: TimezoneConfig = { locale: this.locale, now: this.clock }
+                if (this.zone !== undefined) cfg.zone = this.zone
+                this.tz = new Timezone(cfg)
+            }
+        }
+        return this.tz
+    }
+
+    /** Normaliza ISO string / epoch ms / Date e valida. */
+    private toDate(input: DateInput): Date {
+        if (
+            input === null ||
+            input === undefined ||
+            (typeof input !== "string" && typeof input !== "number" && !(input instanceof Date))
+        ) {
+            throw new Error("Data inválida fornecida")
+        }
+        const date = input instanceof Date ? input : new Date(input)
+        if (isNaN(date.getTime())) throw new Error("Data inválida fornecida")
+        return date
+    }
+
+    /** Rótulo "agora" default a partir do idioma do locale. */
+    private static defaultJustNow(locale: string): string {
+        const lang = locale.toLowerCase().slice(0, 2)
+        return JUST_NOW_BY_LANG[lang] ?? JUST_NOW_BY_LANG.en ?? "just now"
+    }
+
+    // ── conveniências estáticas (locale default pt-BR, relógio do sistema) ────
+    private static readonly defaultInstance = new DateFormatter()
+
+    /** Tempo relativo com os defaults (pt-BR). Conveniência sem instanciar. */
+    public static fromNow(input: DateInput): string {
+        return DateFormatter.defaultInstance.fromNow(input)
+    }
+
+    /** Alias estático de `fromNow`. */
+    public static toRelativeTime(input: DateInput): string {
+        return DateFormatter.defaultInstance.toRelativeTime(input)
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { SentimentExtractor } from "./classes/sentimentExtractor/index.js"
 import { KeywordExtractor } from "./classes/keywordExtractor.js"
 import { RichText } from "./classes/rich.text/index.js"
 import { Timezone } from "./classes/timezone/index.js"
+import { DateFormatter } from "./classes/date/index.js"
 import { Formatter } from "./classes/conversor/index.js"
 
 import type { ValidationConfig } from "./types.js"
@@ -14,6 +15,7 @@ import type { SentimentExtractorConfig } from "./classes/sentimentExtractor/inde
 import type { KeywordExtractorConfig } from "./classes/keywordExtractor.js"
 import type { RichTextConfig } from "./classes/rich.text/index.js"
 import type { TimezoneConfig } from "./classes/timezone/index.js"
+import type { DateFormatterConfig } from "./classes/date/index.js"
 import type { FormatterConfig } from "./classes/conversor/index.js"
 
 /** Cada slot aceita uma config (a mãe constrói a engine) OU uma instância pronta (DI). */
@@ -23,6 +25,7 @@ export interface TextLibraryConfig {
     keywords?: DeepPartial<KeywordExtractorConfig> | KeywordExtractor
     richText?: DeepPartial<RichTextConfig> | RichText
     timezone?: DeepPartial<TimezoneConfig> | Timezone
+    date?: DeepPartial<DateFormatterConfig> | DateFormatter
     format?: DeepPartial<FormatterConfig> | Formatter
 }
 
@@ -49,6 +52,7 @@ export class TextLibrary {
     keywords: KeywordExtractor
     richText: RichText
     timezone: Timezone
+    date: DateFormatter
     format: Formatter
 
     constructor(config: TextLibraryConfig = {}) {
@@ -57,6 +61,12 @@ export class TextLibrary {
         this.keywords = build(config.keywords, (c) => new KeywordExtractor(c))
         this.richText = build(config.richText, (c) => new RichText(undefined, c))
         this.timezone = build(config.timezone, (c) => new Timezone(c))
+        // DateFormatter conversa com o Timezone da fachada por padrão (DI), mas a
+        // config do usuário (locale/zone/instância própria) sempre tem precedência.
+        this.date = build(
+            config.date,
+            (c) => new DateFormatter({ timezone: this.timezone, ...(c as DateFormatterConfig) })
+        )
         this.format = build(config.format, (c) => new Formatter(c))
     }
 
@@ -67,6 +77,7 @@ export class TextLibrary {
         this.keywords = applyPatch(this.keywords, patch.keywords)
         this.richText = applyPatch(this.richText, patch.richText)
         this.timezone = applyPatch(this.timezone, patch.timezone)
+        this.date = applyPatch(this.date, patch.date)
         this.format = applyPatch(this.format, patch.format)
         return this
     }
@@ -79,6 +90,7 @@ export class TextLibrary {
         next.keywords = applyPatch(this.keywords, patch.keywords)
         next.richText = applyPatch(this.richText, patch.richText)
         next.timezone = applyPatch(this.timezone, patch.timezone)
+        next.date = applyPatch(this.date, patch.date)
         next.format = applyPatch(this.format, patch.format)
         return next
     }
@@ -92,4 +104,5 @@ export * from "./classes/sentimentExtractor/index.js"
 export * from "./classes/keywordExtractor.js"
 export * from "./classes/rich.text/index.js"
 export * from "./classes/timezone/index.js"
+export * from "./classes/date/index.js"
 export * from "./classes/conversor/index.js"


### PR DESCRIPTION
## O que muda

Adiciona o **`DateFormatter`**, uma engine independente para **tempo relativo customizável** ("to relative time") em **pt-BR** e **en-US**. É separada do `Timezone`, mas **conversa com ele** para formatação absoluta (DST automático) — e pode ser instanciada sozinha (o tempo relativo não depende de fuso).

### API
- `fromNow` / `toRelativeTime` — relativo customizável: `style` (long/short/narrow), `numeric` (auto/always), `maxUnit`, `justNowThreshold` + `justNowLabel`, `locale`.
- `format` — absoluto, delegado ao `Timezone` (via `zone`, instância injetada `timezone:` ou `withTimezone()`).
- `fromNowOrDate` — híbrido estilo feed (relativo enquanto recente, data absoluta depois).
- Estáticos de conveniência `DateFormatter.fromNow(...)`.

### Integração
- Fachada `TextLibrary`: novo slot `date` (injeta o `Timezone` da fachada por padrão).
- Novo subpath: `circle-text-library/date`.
- Doc: `docs/date.md`; menções no README, CLAUDE.md e `docs/text-library.md`.

### Verificação
- `npm run build` compila limpo (strict + `exactOptionalPropertyTypes`).
- **551 testes passam** (24 arquivos), incluindo **25 novos** para o `DateFormatter`.
- Smoke test contra o `dist` confirma root + subpath + integração com a fachada.

### Release
- Bump de versão **2.0.0 → 2.1.0** (minor: feature retrocompatível).

🤖 Generated with [Claude Code](https://claude.com/claude-code)